### PR TITLE
add bar courner roundness attribute

### DIFF
--- a/src/traces/bar/attributes.js
+++ b/src/traces/bar/attributes.js
@@ -163,7 +163,8 @@ module.exports = {
                 'taking into account direction.',
                 'Value represents percentage of desirable roundness.'
             ].join(' ')
-        }
+        },
+        editType: 'calc'
     },
 
     base: {

--- a/src/traces/bar/attributes.js
+++ b/src/traces/bar/attributes.js
@@ -116,6 +116,56 @@ module.exports = {
         ].join(' ')
     },
 
+    cornerroundness: {
+        bottomleft: {
+            valType: 'number',
+            min: 0,
+            max: 1,
+            dflt: 0,
+            role: 'info',
+            editType: 'calc',
+            description: [
+                'Sets round corner for bar bottom left edge,',
+                'taking into account direction.',
+                'Value represents percentage of desirable roundness.'
+            ].join(' ')
+        },
+        bottomright: {
+            valType: 'number',
+            min: 0,
+            max: 1,
+            dflt: 0,
+            role: 'info',
+            editType: 'calc',
+        },
+        topleft: {
+            valType: 'number',
+            min: 0,
+            max: 1,
+            dflt: 0,
+            role: 'info',
+            editType: 'calc',
+            description: [
+                'Sets round corner for bar top left edge,',
+                'taking into account direction.',
+                'Value represents percentage of desirable roundness.'
+            ].join(' ')
+        },
+        topright: {
+            valType: 'number',
+            min: 0,
+            max: 1,
+            dflt: 0,
+            role: 'info',
+            editType: 'calc',
+            description: [
+                'Sets round corner for bar top right edge,',
+                'taking into account direction.',
+                'Value represents percentage of desirable roundness.'
+            ].join(' ')
+        }
+    },
+
     base: {
         valType: 'any',
         dflt: null,

--- a/src/traces/bar/defaults.js
+++ b/src/traces/bar/defaults.js
@@ -31,10 +31,13 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
     }
 
     coerce('orientation', (traceOut.x && !traceOut.y) ? 'h' : 'v');
+    coerce('cornerroundness.bottomleft');
+    coerce('cornerroundness.bottomright');
+    coerce('cornerroundness.topleft');
+    coerce('cornerroundness.topright');
     coerce('base');
     coerce('offset');
     coerce('width');
-
     coerce('text');
     coerce('hovertext');
 

--- a/src/traces/bar/plot.js
+++ b/src/traces/bar/plot.js
@@ -116,6 +116,45 @@ module.exports = function plot(gd, plotinfo, cdbar) {
                         (v > vc ? Math.ceil(v) : Math.floor(v));
                     }
 
+                    function generatePathDescription(x0, y0, x1, y1, bl, br, tl, tr) {
+                        if(bl === 0 && br === 0 && tl === 0 && tr === 0) {
+                            return 'M' + x0 + ',' + y0 + 'V' + y1 + 'H' + x1 + 'V' + y0 + 'Z';
+                        }
+
+                        // max allowed arc radius equals least wide edge width divided by two
+                        var r = Math.min(Math.abs(x0 - x1), Math.abs(y0 - y1)) / 2;
+
+                        // handles all possible bar drawing directions
+                        // bottom to top
+                        if(x0 < x1 && y0 > y1) {
+                            return 'M' + (x0 + r * bl) + ',' + y0 + 'A' + r * bl + ',' + r * bl + ' 0 0 1 ' + x0 + ',' + (y0 - r * bl) +
+                                   'V' + (y1 + r * tl) + 'A' + r * tl + ',' + r * tl + ' 0 0 1 ' + (x0 + r * tl) + ',' + (y1) +
+                                   'H' + (x1 - r * tr) + 'A' + r * tr + ',' + r * tr + ' 0 0 1 ' + x1 + ',' + (y1 + r * tr) +
+                                   'V' + (y0 - r * br) + 'A' + r * br + ',' + r * br + ' 0 0 1 ' + (x1 - r * br) + ',' + y0 + 'Z';
+                        }
+                        // top to bottom
+                        if(x0 > x1 && y0 < y1) {
+                            return 'M' + (x0 - r * tr) + ',' + y0 + 'A' + r * tr + ',' + r * tr + ' 0 0 1 ' + x0 + ',' + (y0 + r * tr) +
+                                   'V' + (y1 - r * br) + 'A' + r * br + ',' + r * br + ' 0 0 1 ' + (x0 - r * br) + ',' + (y1) +
+                                   'H' + (x1 + r * bl) + 'A' + r * bl + ',' + r * bl + ' 0 0 1 ' + x1 + ',' + (y1 - r * bl) +
+                                   'V' + (y0 + r * tl) + 'A' + r * tl + ',' + r * tl + ' 0 0 1 ' + (x1 + r * tl) + ',' + y0 + 'Z';
+                        }
+                        // left to right
+                        if(x0 < x1 && y0 < y1) {
+                            return 'M' + (x0 + r * tl) + ',' + y0 + 'A' + r * tl + ',' + r * tl + ' 1 0 0 ' + x0 + ',' + (y0 + r * tl) +
+                                   'V' + (y1 - r * bl) + 'A' + r * bl + ',' + r * bl + ' 1 0 0 ' + (x0 + r * bl) + ',' + (y1) +
+                                   'H' + (x1 - r * br) + 'A' + r * br + ',' + r * br + ' 1 0 0 ' + x1 + ',' + (y1 - r * br) +
+                                   'V' + (y0 + r * tr) + 'A' + r * tr + ',' + r * tr + ' 1 0 0 ' + (x1 - r * tr) + ',' + y0 + 'Z';
+                        }
+                        // right to left
+                        if(x0 > x1 && y0 > y1) {
+                            return 'M' + (x0 - r * br) + ',' + y0 + 'A' + r * br + ',' + r * br + ' 1 0 0 ' + x0 + ',' + (y0 - r * br) +
+                                   'V' + (y1 + r * tr) + 'A' + r * tr + ',' + r * tr + ' 1 0 0 ' + (x0 - r * tr) + ',' + (y1) +
+                                   'H' + (x1 + r * tl) + 'A' + r * tl + ',' + r * tl + ' 1 0 0 ' + x1 + ',' + (y1 + r * tl) +
+                                   'V' + (y0 - r * bl) + 'A' + r * bl + ',' + r * bl + ' 1 0 0 ' + (x1 + r * bl) + ',' + y0 + 'Z';
+                        }
+                    }
+
                     if(!gd._context.staticPlot) {
                         // if bars are not fully opaque or they have a line
                         // around them, round to integer pixels, mainly for
@@ -138,7 +177,11 @@ module.exports = function plot(gd, plotinfo, cdbar) {
                     bar.append('path')
                         .style('vector-effect', 'non-scaling-stroke')
                         .attr('d',
-                            'M' + x0 + ',' + y0 + 'V' + y1 + 'H' + x1 + 'V' + y0 + 'Z');
+                            generatePathDescription(x0, y0, x1, y1,
+                                trace.cornerroundness.bottomleft,
+                                trace.cornerroundness.bottomright,
+                                trace.cornerroundness.topleft,
+                                trace.cornerroundness.topright));
 
                     appendBarText(gd, bar, d, i, x0, x1, y0, y1);
                 });

--- a/src/traces/bar/plot.js
+++ b/src/traces/bar/plot.js
@@ -9,6 +9,7 @@
 
 'use strict';
 
+var _ = require('../../../node_modules/underscore');
 var d3 = require('d3');
 var isNumeric = require('fast-isnumeric');
 var tinycolor = require('tinycolor2');
@@ -31,9 +32,16 @@ var attributes = require('./attributes'),
 var TEXTPAD = 3;
 
 module.exports = function plot(gd, plotinfo, cdbar) {
-    var xa = plotinfo.xaxis,
-        ya = plotinfo.yaxis,
-        fullLayout = gd._fullLayout;
+
+    cdbar.forEach(function(d, i) {
+        cdbar[i] = calculateBarCoordinates(d, plotinfo.xaxis, plotinfo.yaxis, gd._fullLayout, gd._context.staticPlot);
+    });
+
+    if(gd._fullLayout.barmode === 'stack' || gd._fullLayout.barmode === 'relative') {
+        cdbar = calculatePositionInStack(cdbar);
+    }
+
+    var maxBarRadius = getMaxBarRadius(cdbar);
 
     var bartraces = plotinfo.plot.select('.barlayer')
         .selectAll('g.trace.bars')
@@ -50,10 +58,7 @@ module.exports = function plot(gd, plotinfo, cdbar) {
         .attr('class', 'points')
         .each(function(d) {
             var sel = d3.select(this);
-            var t = d[0].t;
             var trace = d[0].trace;
-            var poffset = t.poffset;
-            var poffsetIsArray = Array.isArray(poffset);
 
             sel.selectAll('g.point')
                 .data(Lib.identity)
@@ -63,57 +68,46 @@ module.exports = function plot(gd, plotinfo, cdbar) {
                     // clipped xf/yf (2nd arg true): non-positive
                     // log values go off-screen by plotwidth
                     // so you see them continue if you drag the plot
-                    var p0 = di.p + ((poffsetIsArray) ? poffset[i] : poffset),
-                        p1 = p0 + di.w,
-                        s0 = di.b,
-                        s1 = s0 + di.s;
 
-                    var x0, x1, y0, y1;
-                    if(trace.orientation === 'h') {
-                        y0 = ya.c2p(p0, true);
-                        y1 = ya.c2p(p1, true);
-                        x0 = xa.c2p(s0, true);
-                        x1 = xa.c2p(s1, true);
+                    var blr = trace.cornerroundness.bottomleft,
+                        brr = trace.cornerroundness.bottomright,
+                        tlr = trace.cornerroundness.topleft,
+                        trr = trace.cornerroundness.topright;
 
-                        // for selections
-                        di.ct = [x1, (y0 + y1) / 2];
+                    // in case of stacked bars removes round corners from middle bars.
+                    if(trace.stackPosition) {
+                        if(!trace.stackPosition.bottom[i]) {
+                            if(trace.orientation === 'v') {
+                                blr = 0;
+                                brr = 0;
+                            }
+                            else {
+                                blr = 0;
+                                tlr = 0;
+                            }
+                        }
+                        if(!trace.stackPosition.top[i]) {
+                            if(trace.orientation === 'v') {
+                                tlr = 0;
+                                trr = 0;
+                            }
+                            else {
+                                brr = 0;
+                                trr = 0;
+                            }
+                        }
                     }
-                    else {
-                        x0 = xa.c2p(p0, true);
-                        x1 = xa.c2p(p1, true);
-                        y0 = ya.c2p(s0, true);
-                        y1 = ya.c2p(s1, true);
 
-                        // for selections
-                        di.ct = [(x0 + x1) / 2, y1];
-                    }
+                    var x0 = trace.coordinates[i].x0,
+                        y0 = trace.coordinates[i].y0,
+                        x1 = trace.coordinates[i].x1,
+                        y1 = trace.coordinates[i].y1;
 
                     if(!isNumeric(x0) || !isNumeric(x1) ||
-                            !isNumeric(y0) || !isNumeric(y1) ||
-                            x0 === x1 || y0 === y1) {
+                       !isNumeric(y0) || !isNumeric(y1) ||
+                       x0 === x1 || y0 === y1) {
                         d3.select(this).remove();
                         return;
-                    }
-
-                    var lw = (di.mlw + 1 || trace.marker.line.width + 1 ||
-                            (di.trace ? di.trace.marker.line.width : 0) + 1) - 1,
-                        offset = d3.round((lw / 2) % 1, 2);
-
-                    function roundWithLine(v) {
-                        // if there are explicit gaps, don't round,
-                        // it can make the gaps look crappy
-                        return (fullLayout.bargap === 0 && fullLayout.bargroupgap === 0) ?
-                            d3.round(Math.round(v) - offset, 2) : v;
-                    }
-
-                    function expandToVisible(v, vc) {
-                        // if it's not in danger of disappearing entirely,
-                        // round more precisely
-                        return Math.abs(v - vc) >= 2 ? roundWithLine(v) :
-                        // but if it's very thin, expand it so it's
-                        // necessarily visible, even if it might overlap
-                        // its neighbor
-                        (v > vc ? Math.ceil(v) : Math.floor(v));
                     }
 
                     function generatePathDescription(x0, y0, x1, y1, bl, br, tl, tr) {
@@ -122,7 +116,7 @@ module.exports = function plot(gd, plotinfo, cdbar) {
                         }
 
                         // max allowed arc radius equals least wide edge width divided by two
-                        var r = Math.min(Math.abs(x0 - x1), Math.abs(y0 - y1)) / 2;
+                        var r = maxBarRadius;
 
                         // handles all possible bar drawing directions
                         // bottom to top
@@ -155,33 +149,13 @@ module.exports = function plot(gd, plotinfo, cdbar) {
                         }
                     }
 
-                    if(!gd._context.staticPlot) {
-                        // if bars are not fully opaque or they have a line
-                        // around them, round to integer pixels, mainly for
-                        // safari so we prevent overlaps from its expansive
-                        // pixelation. if the bars ARE fully opaque and have
-                        // no line, expand to a full pixel to make sure we
-                        // can see them
-                        var op = Color.opacity(di.mc || trace.marker.color),
-                            fixpx = (op < 1 || lw > 0.01) ?
-                                roundWithLine : expandToVisible;
-                        x0 = fixpx(x0, x1);
-                        x1 = fixpx(x1, x0);
-                        y0 = fixpx(y0, y1);
-                        y1 = fixpx(y1, y0);
-                    }
-
                     // append bar path and text
                     var bar = d3.select(this);
 
                     bar.append('path')
                         .style('vector-effect', 'non-scaling-stroke')
                         .attr('d',
-                            generatePathDescription(x0, y0, x1, y1,
-                                trace.cornerroundness.bottomleft,
-                                trace.cornerroundness.bottomright,
-                                trace.cornerroundness.topleft,
-                                trace.cornerroundness.topright));
+                            generatePathDescription(x0, y0, x1, y1, blr, brr, tlr, trr));
 
                     appendBarText(gd, bar, d, i, x0, x1, y0, y1);
                 });
@@ -307,6 +281,151 @@ function appendBarText(gd, bar, calcTrace, i, x0, x1, y0, y1) {
     }
 
     textSelection.attr('transform', transform);
+}
+
+function calculateBarCoordinates(d, xa, ya, fullLayout, staticPlot) {
+    var t = d[0].t;
+    var trace = d[0].trace;
+    var poffset = t.poffset;
+    var poffsetIsArray = Array.isArray(poffset);
+
+    trace.coordinates = [];
+
+    d.forEach(function(di, i) {
+        var p0 = di.p + ((poffsetIsArray) ? poffset[i] : poffset),
+            p1 = p0 + di.w,
+            s0 = di.b,
+            s1 = s0 + di.s;
+
+        var x0, x1, y0, y1;
+
+        if(trace.orientation === 'h') {
+            y0 = ya.c2p(p0, true);
+            y1 = ya.c2p(p1, true);
+            x0 = xa.c2p(s0, true);
+            x1 = xa.c2p(s1, true);
+            // for selections
+            di.ct = [x1, (y0 + y1) / 2];
+        }
+        else {
+            x0 = xa.c2p(p0, true);
+            x1 = xa.c2p(p1, true);
+            y0 = ya.c2p(s0, true);
+            y1 = ya.c2p(s1, true);
+            // for selections
+            di.ct = [(x0 + x1) / 2, y1];
+        }
+
+        var lw = (di.mlw + 1 || trace.marker.line.width + 1 ||
+            (di.trace ? trace.marker.line.width : 0) + 1) - 1,
+            offset = d3.round((lw / 2) % 1, 2);
+
+        if(!staticPlot) {
+            // if bars are not fully opaque or they have a line
+            // around them, round to integer pixels, mainly for
+            // safari so we prevent overlaps from its expansive
+            // pixelation. if the bars ARE fully opaque and have
+            // no line, expand to a full pixel to make sure we
+            // can see them
+            var op = Color.opacity(di.mc || trace.marker.color),
+                fixpx = (op < 1 || lw > 0.01) ?
+                    roundWithLine : expandToVisible;
+
+            x0 = fixpx(x0, x1);
+            x1 = fixpx(x1, x0);
+            y0 = fixpx(y0, y1);
+            y1 = fixpx(y1, y0);
+        }
+
+        trace.coordinates.push({ x0: x0, y0: y0, x1: x1, y1: y1 });
+        d[i].ct = d[0].ct;
+
+        function roundWithLine(v) {
+            // if there are explicit gaps, don't round,
+            // it can make the gaps look crappy
+            return (fullLayout.bargap === 0 && fullLayout.bargroupgap === 0) ?
+                d3.round(Math.round(v) - offset, 2) : v;
+        }
+
+        function expandToVisible(v, vc) {
+            // if it's not in danger of disappearing entirely,
+            // round more precisely
+            return Math.abs(v - vc) >= 2 ? roundWithLine(v) :
+            // but if it's very thin, expand it so it's
+            // necessarily visible, even if it might overlap
+            // its neighbor
+            (v > vc ? Math.ceil(v) : Math.floor(v));
+        }
+    });
+    d[0].trace = trace;
+    return d;
+}
+
+function calculatePositionInStack(cdbar) {
+    // calculate which bars go into which stack,
+    // and whether the bar is in stack top or bottom
+    var array = [];
+    for(var i = 0; i < cdbar.length; i++) {
+        var object = (cdbar[i][0].trace.orientation === 'v') ? _.object(cdbar[i][0].trace.x, cdbar[i][0].trace.y) : _.object(cdbar[i][0].trace.y, cdbar[i][0].trace.x);
+        array.push(object);
+    }
+    var index = 0;
+    array.reverse().forEach(function(o) {
+        var cdbarIndex = array.length - index - 1;
+        cdbar[cdbarIndex][0].trace.stackPosition = {
+            bottom: [],
+            top: []
+        };
+        Object.keys(o).forEach(function(key) {
+            var topResult = true;
+            var bottomResult = true;
+            if(o[key] === null) {
+                topResult = bottomResult = false;
+            }
+            else {
+                var j = index;
+                while(--j >= 0) {
+                    if(!bottomResult && !topResult) break;
+                    if(array[j].hasOwnProperty(key)) {
+                        if(array[index][key] < 0 && array[j][key] < 0) bottomResult = false;
+                        if(array[index][key] < 0 && array[j][key] > 0) topResult = false;
+                        if(array[index][key] >= 0 && array[j][key] > 0) topResult = false;
+                        if(array[index][key] >= 0 && array[j][key] < 0) bottomResult = false;
+                    }
+                }
+                j = index;
+                while(++j < array.length) {
+                    if(!bottomResult && !topResult) break;
+                    if(array[j].hasOwnProperty(key)) {
+                        if(array[index][key] < 0 && array[j][key]) topResult = false;
+                        if(array[index][key] >= 0 && array[j][key]) bottomResult = false;
+                    }
+                }
+            }
+            cdbar[cdbarIndex][0].trace.stackPosition.bottom.push(bottomResult);
+            cdbar[cdbarIndex][0].trace.stackPosition.top.push(topResult);
+        });
+        index++;
+    });
+    return cdbar;
+}
+
+function getMaxBarRadius(cdbar) {
+    // max bar roundness radius is equal to least widest bar width,
+    // so all the bars look the same otherwise larger bars will look completely
+    // different from very small bar. If high roundness percentage is used.
+    var maxBarRadius = null;
+    cdbar.forEach(function(d) {
+        d[0].trace.coordinates.forEach(function(di, i) {
+            // skip bars that aren't in the top or the bottom of the bar.
+            if(d[0].trace.stackPosition && (!d[0].trace.stackPosition.bottom[i] && !d[0].trace.stackPosition.top[i])) return;
+            else {
+                var r = Math.min(Math.abs(di.x0 - di.x1), Math.abs(di.y0 - di.y1)) / 2;
+                maxBarRadius = (maxBarRadius > r || !isNumeric(maxBarRadius)) ? r : maxBarRadius;
+            }
+        });
+    });
+    return (maxBarRadius !== null) ? maxBarRadius : 0;
 }
 
 function getTransformToMoveInsideBar(x0, x1, y0, y1, textBB, orientation, constrained) {

--- a/src/traces/bar/plot.js
+++ b/src/traces/bar/plot.js
@@ -32,9 +32,10 @@ var attributes = require('./attributes'),
 var TEXTPAD = 3;
 
 module.exports = function plot(gd, plotinfo, cdbar) {
+    var fullLayout = gd._fullLayout;
 
     cdbar.forEach(function(d, i) {
-        cdbar[i] = calculateBarCoordinates(d, plotinfo.xaxis, plotinfo.yaxis, gd._fullLayout, gd._context.staticPlot);
+        cdbar[i] = calculateBarCoordinates(d, plotinfo.xaxis, plotinfo.yaxis);
     });
 
     if(gd._fullLayout.barmode === 'stack' || gd._fullLayout.barmode === 'relative') {
@@ -55,111 +56,151 @@ module.exports = function plot(gd, plotinfo, cdbar) {
     });
 
     bartraces.append('g')
-        .attr('class', 'points')
-        .each(function(d) {
-            var sel = d3.select(this);
-            var trace = d[0].trace;
+    .attr('class', 'points')
+    .each(function(d) {
+        var sel = d3.select(this);
+        var trace = d[0].trace;
 
-            sel.selectAll('g.point')
-                .data(Lib.identity)
-              .enter().append('g').classed('point', true)
-                .each(function(di, i) {
-                    // now display the bar
-                    // clipped xf/yf (2nd arg true): non-positive
-                    // log values go off-screen by plotwidth
-                    // so you see them continue if you drag the plot
+        sel.selectAll('g.point')
+            .data(Lib.identity)
+          .enter().append('g').classed('point', true)
+            .each(function(di, i) {
+                // now display the bar
+                // clipped xf/yf (2nd arg true): non-positive
+                // log values go off-screen by plotwidth
+                // so you see them continue if you drag the plot
 
-                    var blr = trace.cornerroundness.bottomleft,
-                        brr = trace.cornerroundness.bottomright,
-                        tlr = trace.cornerroundness.topleft,
-                        trr = trace.cornerroundness.topright;
+                var x0, x1, y0, y1;
 
-                    // in case of stacked bars removes round corners from middle bars.
-                    if(trace.stackPosition) {
-                        if(!trace.stackPosition.bottom[i]) {
-                            if(trace.orientation === 'v') {
-                                blr = 0;
-                                brr = 0;
-                            }
-                            else {
-                                blr = 0;
-                                tlr = 0;
-                            }
+                x0 = trace.coordinates[i].x0,
+                y0 = trace.coordinates[i].y0,
+                x1 = trace.coordinates[i].x1,
+                y1 = trace.coordinates[i].y1,
+                di.ct = trace.coordinates[i].ct;
+
+                if(!isNumeric(x0) || !isNumeric(x1) ||
+                        !isNumeric(y0) || !isNumeric(y1) ||
+                        x0 === x1 || y0 === y1) {
+                    d3.select(this).remove();
+                    return;
+                }
+
+                var blr = trace.cornerroundness.bottomleft,
+                    brr = trace.cornerroundness.bottomright,
+                    tlr = trace.cornerroundness.topleft,
+                    trr = trace.cornerroundness.topright;
+
+                // in case of stacked bars removes round corners from middle bars.
+                if(trace.stackPosition) {
+                    if(!trace.stackPosition.bottom[i]) {
+                        if(trace.orientation === 'v') {
+                            blr = 0;
+                            brr = 0;
                         }
-                        if(!trace.stackPosition.top[i]) {
-                            if(trace.orientation === 'v') {
-                                tlr = 0;
-                                trr = 0;
-                            }
-                            else {
-                                brr = 0;
-                                trr = 0;
-                            }
-                        }
-                    }
-
-                    var x0 = trace.coordinates[i].x0,
-                        y0 = trace.coordinates[i].y0,
-                        x1 = trace.coordinates[i].x1,
-                        y1 = trace.coordinates[i].y1;
-
-                    if(!isNumeric(x0) || !isNumeric(x1) ||
-                       !isNumeric(y0) || !isNumeric(y1) ||
-                       x0 === x1 || y0 === y1) {
-                        d3.select(this).remove();
-                        return;
-                    }
-
-                    function generatePathDescription(x0, y0, x1, y1, bl, br, tl, tr) {
-                        if(bl === 0 && br === 0 && tl === 0 && tr === 0) {
-                            return 'M' + x0 + ',' + y0 + 'V' + y1 + 'H' + x1 + 'V' + y0 + 'Z';
-                        }
-
-                        // max allowed arc radius equals least wide edge width divided by two
-                        var r = maxBarRadius;
-
-                        // handles all possible bar drawing directions
-                        // bottom to top
-                        if(x0 < x1 && y0 > y1) {
-                            return 'M' + (x0 + r * bl) + ',' + y0 + 'A' + r * bl + ',' + r * bl + ' 0 0 1 ' + x0 + ',' + (y0 - r * bl) +
-                                   'V' + (y1 + r * tl) + 'A' + r * tl + ',' + r * tl + ' 0 0 1 ' + (x0 + r * tl) + ',' + (y1) +
-                                   'H' + (x1 - r * tr) + 'A' + r * tr + ',' + r * tr + ' 0 0 1 ' + x1 + ',' + (y1 + r * tr) +
-                                   'V' + (y0 - r * br) + 'A' + r * br + ',' + r * br + ' 0 0 1 ' + (x1 - r * br) + ',' + y0 + 'Z';
-                        }
-                        // top to bottom
-                        if(x0 > x1 && y0 < y1) {
-                            return 'M' + (x0 - r * tr) + ',' + y0 + 'A' + r * tr + ',' + r * tr + ' 0 0 1 ' + x0 + ',' + (y0 + r * tr) +
-                                   'V' + (y1 - r * br) + 'A' + r * br + ',' + r * br + ' 0 0 1 ' + (x0 - r * br) + ',' + (y1) +
-                                   'H' + (x1 + r * bl) + 'A' + r * bl + ',' + r * bl + ' 0 0 1 ' + x1 + ',' + (y1 - r * bl) +
-                                   'V' + (y0 + r * tl) + 'A' + r * tl + ',' + r * tl + ' 0 0 1 ' + (x1 + r * tl) + ',' + y0 + 'Z';
-                        }
-                        // left to right
-                        if(x0 < x1 && y0 < y1) {
-                            return 'M' + (x0 + r * tl) + ',' + y0 + 'A' + r * tl + ',' + r * tl + ' 1 0 0 ' + x0 + ',' + (y0 + r * tl) +
-                                   'V' + (y1 - r * bl) + 'A' + r * bl + ',' + r * bl + ' 1 0 0 ' + (x0 + r * bl) + ',' + (y1) +
-                                   'H' + (x1 - r * br) + 'A' + r * br + ',' + r * br + ' 1 0 0 ' + x1 + ',' + (y1 - r * br) +
-                                   'V' + (y0 + r * tr) + 'A' + r * tr + ',' + r * tr + ' 1 0 0 ' + (x1 - r * tr) + ',' + y0 + 'Z';
-                        }
-                        // right to left
-                        if(x0 > x1 && y0 > y1) {
-                            return 'M' + (x0 - r * br) + ',' + y0 + 'A' + r * br + ',' + r * br + ' 1 0 0 ' + x0 + ',' + (y0 - r * br) +
-                                   'V' + (y1 + r * tr) + 'A' + r * tr + ',' + r * tr + ' 1 0 0 ' + (x0 - r * tr) + ',' + (y1) +
-                                   'H' + (x1 + r * tl) + 'A' + r * tl + ',' + r * tl + ' 1 0 0 ' + x1 + ',' + (y1 + r * tl) +
-                                   'V' + (y0 - r * bl) + 'A' + r * bl + ',' + r * bl + ' 1 0 0 ' + (x1 + r * bl) + ',' + y0 + 'Z';
+                        else {
+                            blr = 0;
+                            tlr = 0;
                         }
                     }
+                    if(!trace.stackPosition.top[i]) {
+                        if(trace.orientation === 'v') {
+                            tlr = 0;
+                            trr = 0;
+                        }
+                        else {
+                            brr = 0;
+                            trr = 0;
+                        }
+                    }
+                }
 
-                    // append bar path and text
-                    var bar = d3.select(this);
+                var lw = (di.mlw + 1 || trace.marker.line.width + 1 ||
+                    (di.trace ? di.trace.marker.line.width : 0) + 1) - 1,
+                    offset = d3.round((lw / 2) % 1, 2);
 
-                    bar.append('path')
-                        .style('vector-effect', 'non-scaling-stroke')
-                        .attr('d',
-                            generatePathDescription(x0, y0, x1, y1, blr, brr, tlr, trr));
+                function roundWithLine(v) {
+                    // if there are explicit gaps, don't round,
+                    // it can make the gaps look crappy
+                    return (fullLayout.bargap === 0 && fullLayout.bargroupgap === 0) ?
+                        d3.round(Math.round(v) - offset, 2) : v;
+                }
 
-                    appendBarText(gd, bar, d, i, x0, x1, y0, y1);
-                });
-        });
+                function expandToVisible(v, vc) {
+                    // if it's not in danger of disappearing entirely,
+                    // round more precisely
+                    return Math.abs(v - vc) >= 2 ? roundWithLine(v) :
+                    // but if it's very thin, expand it so it's
+                    // necessarily visible, even if it might overlap
+                    // its neighbor
+                    (v > vc ? Math.ceil(v) : Math.floor(v));
+                }
+
+                function generatePathDescription(x0, y0, x1, y1, bl, br, tl, tr) {
+                    if(bl === 0 && br === 0 && tl === 0 && tr === 0) {
+                        return 'M' + x0 + ',' + y0 + 'V' + y1 + 'H' + x1 + 'V' + y0 + 'Z';
+                    }
+
+                    // max allowed arc radius equals least wide edge width divided by two
+                    var r = maxBarRadius;
+
+                    // handles all possible bar drawing directions
+                    // bottom to top
+                    if(x0 < x1 && y0 > y1) {
+                        return 'M' + (x0 + r * bl) + ',' + y0 + 'A' + r * bl + ',' + r * bl + ' 0 0 1 ' + x0 + ',' + (y0 - r * bl) +
+                               'V' + (y1 + r * tl) + 'A' + r * tl + ',' + r * tl + ' 0 0 1 ' + (x0 + r * tl) + ',' + (y1) +
+                               'H' + (x1 - r * tr) + 'A' + r * tr + ',' + r * tr + ' 0 0 1 ' + x1 + ',' + (y1 + r * tr) +
+                               'V' + (y0 - r * br) + 'A' + r * br + ',' + r * br + ' 0 0 1 ' + (x1 - r * br) + ',' + y0 + 'Z';
+                    }
+                    // top to bottom
+                    if(x0 > x1 && y0 < y1) {
+                        return 'M' + (x0 - r * tr) + ',' + y0 + 'A' + r * tr + ',' + r * tr + ' 0 0 1 ' + x0 + ',' + (y0 + r * tr) +
+                               'V' + (y1 - r * br) + 'A' + r * br + ',' + r * br + ' 0 0 1 ' + (x0 - r * br) + ',' + (y1) +
+                               'H' + (x1 + r * bl) + 'A' + r * bl + ',' + r * bl + ' 0 0 1 ' + x1 + ',' + (y1 - r * bl) +
+                               'V' + (y0 + r * tl) + 'A' + r * tl + ',' + r * tl + ' 0 0 1 ' + (x1 + r * tl) + ',' + y0 + 'Z';
+                    }
+                    // left to right
+                    if(x0 < x1 && y0 < y1) {
+                        return 'M' + (x0 + r * tl) + ',' + y0 + 'A' + r * tl + ',' + r * tl + ' 1 0 0 ' + x0 + ',' + (y0 + r * tl) +
+                               'V' + (y1 - r * bl) + 'A' + r * bl + ',' + r * bl + ' 1 0 0 ' + (x0 + r * bl) + ',' + (y1) +
+                               'H' + (x1 - r * br) + 'A' + r * br + ',' + r * br + ' 1 0 0 ' + x1 + ',' + (y1 - r * br) +
+                               'V' + (y0 + r * tr) + 'A' + r * tr + ',' + r * tr + ' 1 0 0 ' + (x1 - r * tr) + ',' + y0 + 'Z';
+                    }
+                    // right to left
+                    if(x0 > x1 && y0 > y1) {
+                        return 'M' + (x0 - r * br) + ',' + y0 + 'A' + r * br + ',' + r * br + ' 1 0 0 ' + x0 + ',' + (y0 - r * br) +
+                               'V' + (y1 + r * tr) + 'A' + r * tr + ',' + r * tr + ' 1 0 0 ' + (x0 - r * tr) + ',' + (y1) +
+                               'H' + (x1 + r * tl) + 'A' + r * tl + ',' + r * tl + ' 1 0 0 ' + x1 + ',' + (y1 + r * tl) +
+                               'V' + (y0 - r * bl) + 'A' + r * bl + ',' + r * bl + ' 1 0 0 ' + (x1 + r * bl) + ',' + y0 + 'Z';
+                    }
+                }
+
+                if(!gd._context.staticPlot) {
+                    // if bars are not fully opaque or they have a line
+                    // around them, round to integer pixels, mainly for
+                    // safari so we prevent overlaps from its expansive
+                    // pixelation. if the bars ARE fully opaque and have
+                    // no line, expand to a full pixel to make sure we
+                    // can see them
+                    var op = Color.opacity(di.mc || trace.marker.color),
+                        fixpx = (op < 1 || lw > 0.01) ?
+                            roundWithLine : expandToVisible;
+                    x0 = fixpx(x0, x1);
+                    x1 = fixpx(x1, x0);
+                    y0 = fixpx(y0, y1);
+                    y1 = fixpx(y1, y0);
+                }
+
+                // append bar path and text
+                var bar = d3.select(this);
+
+                bar.append('path')
+                    .style('vector-effect', 'non-scaling-stroke')
+                    .attr('d',
+                        generatePathDescription(x0, y0, x1, y1, blr, brr, tlr, trr));
+
+                appendBarText(gd, bar, d, i, x0, x1, y0, y1);
+            });
+    });
 
     // error bars are on the top
     bartraces.call(ErrorBars.plot, plotinfo);
@@ -283,7 +324,8 @@ function appendBarText(gd, bar, calcTrace, i, x0, x1, y0, y1) {
     textSelection.attr('transform', transform);
 }
 
-function calculateBarCoordinates(d, xa, ya, fullLayout, staticPlot) {
+function calculateBarCoordinates(d, xa, ya) {
+    // calculates bar coordinates in order to later find out appropriate corner roundness radius
     var t = d[0].t;
     var trace = d[0].trace;
     var poffset = t.poffset;
@@ -296,9 +338,7 @@ function calculateBarCoordinates(d, xa, ya, fullLayout, staticPlot) {
             p1 = p0 + di.w,
             s0 = di.b,
             s1 = s0 + di.s;
-
         var x0, x1, y0, y1;
-
         if(trace.orientation === 'h') {
             y0 = ya.c2p(p0, true);
             y1 = ya.c2p(p1, true);
@@ -315,47 +355,7 @@ function calculateBarCoordinates(d, xa, ya, fullLayout, staticPlot) {
             // for selections
             di.ct = [(x0 + x1) / 2, y1];
         }
-
-        var lw = (di.mlw + 1 || trace.marker.line.width + 1 ||
-            (di.trace ? trace.marker.line.width : 0) + 1) - 1,
-            offset = d3.round((lw / 2) % 1, 2);
-
-        if(!staticPlot) {
-            // if bars are not fully opaque or they have a line
-            // around them, round to integer pixels, mainly for
-            // safari so we prevent overlaps from its expansive
-            // pixelation. if the bars ARE fully opaque and have
-            // no line, expand to a full pixel to make sure we
-            // can see them
-            var op = Color.opacity(di.mc || trace.marker.color),
-                fixpx = (op < 1 || lw > 0.01) ?
-                    roundWithLine : expandToVisible;
-
-            x0 = fixpx(x0, x1);
-            x1 = fixpx(x1, x0);
-            y0 = fixpx(y0, y1);
-            y1 = fixpx(y1, y0);
-        }
-
-        trace.coordinates.push({ x0: x0, y0: y0, x1: x1, y1: y1 });
-        d[i].ct = d[0].ct;
-
-        function roundWithLine(v) {
-            // if there are explicit gaps, don't round,
-            // it can make the gaps look crappy
-            return (fullLayout.bargap === 0 && fullLayout.bargroupgap === 0) ?
-                d3.round(Math.round(v) - offset, 2) : v;
-        }
-
-        function expandToVisible(v, vc) {
-            // if it's not in danger of disappearing entirely,
-            // round more precisely
-            return Math.abs(v - vc) >= 2 ? roundWithLine(v) :
-            // but if it's very thin, expand it so it's
-            // necessarily visible, even if it might overlap
-            // its neighbor
-            (v > vc ? Math.ceil(v) : Math.floor(v));
-        }
+        trace.coordinates.push({ x0: x0, y0: y0, x1: x1, y1: y1, ct: di.ct });
     });
     d[0].trace = trace;
     return d;

--- a/src/traces/histogram/attributes.js
+++ b/src/traces/histogram/attributes.js
@@ -29,6 +29,7 @@ module.exports = {
 
     text: barAttrs.text,
     orientation: barAttrs.orientation,
+    cornerroundness: barAttrs.cornerroundness,
 
     histfunc: {
         valType: 'enumerated',

--- a/src/traces/histogram/defaults.js
+++ b/src/traces/histogram/defaults.js
@@ -37,6 +37,11 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
     var orientation = coerce('orientation', (y && !x) ? 'h' : 'v'),
         sample = traceOut[orientation === 'v' ? 'x' : 'y'];
 
+    coerce('cornerroundness.bottomleft');
+    coerce('cornerroundness.bottomright');
+    coerce('cornerroundness.topleft');
+    coerce('cornerroundness.topright');
+
     if(!(sample && sample.length)) {
         traceOut.visible = false;
         return;

--- a/test/image/mocks/bar_attr_cornerroundness.json
+++ b/test/image/mocks/bar_attr_cornerroundness.json
@@ -2,7 +2,7 @@
     "data": [
     {
         "x": [10, 7, 9],
-        "y": [18, 24, 13],
+        "y": [-8, -14, -3],
         "name": "Horizontal right values",
         "orientation": "h",
         "cornerroundness": {

--- a/test/image/mocks/bar_attr_cornerroundness.json
+++ b/test/image/mocks/bar_attr_cornerroundness.json
@@ -1,0 +1,85 @@
+{
+    "data": [
+    {
+        "x": [10, 7, 9],
+        "y": [18, 24, 13],
+        "name": "Horizontal right values",
+        "orientation": "h",
+        "cornerroundness": {
+            "bottomleft": 0,
+            "bottomright": 1,
+            "topleft": 0,
+            "topright": 1
+        },
+        "marker": {
+          "color": "rgba(60,60,60,0.6)"
+        },
+        "type": "bar"
+    },
+    {
+        "x": [-10, -7, -9],
+        "y": [18, 24, 13],
+        "name": "Horizontal left values",
+        "orientation": "h",
+        "cornerroundness": {
+            "bottomleft": 0.3,
+            "bottomright": 0,
+            "topleft": 0.3,
+            "topright": 0
+        },
+        "marker": {
+          "color": "rgba(0,120,120,0.6)"
+        },
+        "type": "bar"
+    },
+    {
+        "x": [2, 5, 7],
+        "y": [5, 20, 13],
+        "name": "Vertical up values",
+        "orientation": "v",
+        "cornerroundness": {
+            "bottomleft": 0,
+            "bottomright": 0,
+            "topleft": 1,
+            "topright": 1
+        },
+        "type": "bar",
+        "marker": {
+          "color": "rgba(255,0,255,0.6)"
+        }
+      },
+      {
+        "x": [-2, -5, -7],
+        "y": [-5, -20, -13],
+        "name": "Vertical down values",
+        "orientation": "v",
+        "cornerroundness": {
+            "bottomleft": 0.5,
+            "bottomright": 0.5,
+            "topleft": 0,
+            "topright": 0
+        },
+        "type": "bar",
+        "marker": {
+          "color": "rgba(0,0,255,0.6)"
+        }
+      }
+    ],
+    "layout": {
+        "xaxis": {
+            "showgrid": true,
+            "zeroline": true,
+            "tickwidth": 4,
+            "tickcolor": "#000",
+            "title": "X axis"
+        },
+        "yaxis": {
+            "showgrid": true,
+            "zeroline": true,
+            "tickwidth": 4,
+            "tickcolor": "#000",
+            "title": "Y axis"
+        },
+        "title": "Corner roundness"
+    }
+}

--- a/test/image/mocks/bar_stackrelative-with-cornerroundness.json
+++ b/test/image/mocks/bar_stackrelative-with-cornerroundness.json
@@ -1,0 +1,57 @@
+{
+  "data":[
+      {
+          "name":"Col1",
+          "y":["-1","2","3","4","5"],
+          "x":["1","2","3","4","5"],
+          "cornerroundness": {
+            "bottomleft": 1,
+            "bottomright": 1,
+            "topleft": 1,
+            "topright": 1
+          },
+          "type":"bar"
+      },
+      {
+          "name":"Col2",
+          "y":["2","3","4","-3","2"],
+          "x":["1","2","3","4","5"],
+          "cornerroundness": {
+            "bottomleft": 1,
+            "bottomright": 1,
+            "topleft": 1,
+            "topright": 1
+          },
+          "type":"bar"
+      },
+      {
+        "name":"Col3",
+        "y":["-3","0","1","3","-3"],
+        
+        "x":["1","2","3","4","5"],
+        "cornerroundness": {
+          "bottomleft": 1,
+          "bottomright": 1,
+          "topleft": 1,
+          "topright": 1
+        },
+        "type":"bar"
+    },
+    {
+      "name":"Col4",
+      "y":[null,"4","3","-2","2"],
+      "x":["1","2","3","4","5"],
+      "cornerroundness": {
+        "bottomleft": 1,
+        "bottomright": 1,
+        "topleft": 1,
+        "topright": 1
+      },
+      "type":"bar"
+    }
+  ],
+  "layout":{
+      "barmode":"relative",
+      "barnorm":"percent"
+  }
+}


### PR DESCRIPTION
This PR adds a possibility to adjust roundness of trace bar corners.
Each corners roundness can be adjusted individually. 
Value passed represents percentage of desirable roundness.
`      "cornerroundness": {
            "bottomleft": 0.3,
            "bottomright": 0,
            "topleft": 0.3,
            "topright": 0
        }
`
This is implemented by taking calculated vector values in `bar\plot.js` file and adjusting them when generating `svg path description attribute`. 
Round corners are drawn with absolute elliptical arc curve command `A`.  
Arc radius is calculated by taking the smallest edge width of all bars and dividing it by two and then applying desired roundness percentage value.
All four possible vector drawing directions are handled.
![image](https://user-images.githubusercontent.com/21690577/34103014-d77ee45e-e3f3-11e7-9220-9bda8da55dd3.png)
![image](https://user-images.githubusercontent.com/21690577/34103034-ed95ef94-e3f3-11e7-88ca-324d364170ce.png)
